### PR TITLE
goes-bmc: Update to goes v1.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/platinasystems/goes-bmc
 require (
 	github.com/platinasystems/atsock v1.1.0
 	github.com/platinasystems/fdt v1.0.0
-	github.com/platinasystems/goes v1.4.2
+	github.com/platinasystems/goes v1.4.5
 	github.com/platinasystems/gpio v1.0.0
 	github.com/platinasystems/log v1.2.1
 	github.com/platinasystems/redis v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -37,12 +37,16 @@ github.com/platinasystems/go-redis-server v0.0.0-20181030193423-fcb8fa742b73 h1:
 github.com/platinasystems/go-redis-server v0.0.0-20181030193423-fcb8fa742b73/go.mod h1:/GXF5FQty+9BTtfCsfFuD4/pHf/b2cN3f3Ic0nLagQw=
 github.com/platinasystems/goes v1.4.2 h1:I4Vh9Y/regBIm91Ffn2kXeUHc9wEDh7gch5UHyj+1hg=
 github.com/platinasystems/goes v1.4.2/go.mod h1:ddu7eH3ThDVMlIrVxqXDHLbV/xmm8FogSjjPIkC/QvI=
+github.com/platinasystems/goes v1.4.5 h1:9oBqnNyvjg75f9HpFrlEju7RY3PWUPe4lEdv+j6OQZU=
+github.com/platinasystems/goes v1.4.5/go.mod h1:nBcq2/YA1mAskOwhmY3HZKFkYr+qkUBayhaZZmKX1Qk=
 github.com/platinasystems/gpio v0.0.0-20181120172958-aa9a44e83566 h1:K+WxE4dE01A4ZagXVNHd81J6PBubuP7r/2nNzqhkRTs=
 github.com/platinasystems/gpio v0.0.0-20181120172958-aa9a44e83566/go.mod h1:UsR1pB6U/S7Ql6RDrF/S6rMJqWOiZu3H2mKQeEe4v7U=
 github.com/platinasystems/gpio v1.0.0 h1:95YU/4i9dA7WxuSTQQSTevBWj578UZc1CUlhfvavtvM=
 github.com/platinasystems/gpio v1.0.0/go.mod h1:UsR1pB6U/S7Ql6RDrF/S6rMJqWOiZu3H2mKQeEe4v7U=
 github.com/platinasystems/i2c v1.1.0 h1:34ewZSwxMvtD5kYjJAhNtwmEsCFjiQt+o6OJ62Ni2ug=
 github.com/platinasystems/i2c v1.1.0/go.mod h1:Yj5hRxt+HXbW1rXv9aTtxUNZsegDjeWerUPY5BIjDVM=
+github.com/platinasystems/i2c v1.2.0 h1:H1BgNrz4s15AcR6Y4WxZS+eMgX00pu8ZoLfVHb5VoIw=
+github.com/platinasystems/i2c v1.2.0/go.mod h1:Yj5hRxt+HXbW1rXv9aTtxUNZsegDjeWerUPY5BIjDVM=
 github.com/platinasystems/liner v0.0.0-20170801164932-8dd8fbd0e16d h1:jVkqqhZKx8eAb94QYDajS9KOh5B/rOAx34H7DDZGrEo=
 github.com/platinasystems/liner v0.0.0-20170801164932-8dd8fbd0e16d/go.mod h1:5N7zNCEtHP1s5kK6pVgaFwtzEleCreRubeHBnE4rGso=
 github.com/platinasystems/log v1.1.0 h1:hjWJskNV5QC36B+fz9rIyZjMztXZeRnOCypoSALlsm4=

--- a/goes.go
+++ b/goes.go
@@ -190,7 +190,7 @@ var Goes = &goes.Goes{
 		"ping":    ping.Command{},
 		"ps":      ps.Command{},
 		"pwd":     pwd.Command{},
-		"reboot":  reboot.Command{},
+		"reboot":  &reboot.Command{},
 		"redisd": &redisd.Command{
 			Devs:    []string{"lo", "eth0"},
 			Machine: "platina-mk1-bmc",


### PR DESCRIPTION
Mainly to pick up i2c fixes - goes-bmc is now fully compatible with
v4.18!

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>